### PR TITLE
[SAAS-5604] Replace default kubernetes-apiserver-error rules

### DIFF
--- a/alerts.yaml.erb
+++ b/alerts.yaml.erb
@@ -25,4 +25,7 @@
 - name: node.alerts
   rules:
     <%= file 'alerts/node.yaml', 10 %>
+- name: kube-apiserver-error.alerts
+  rules:
+    <%= file 'alerts/kube-apiserver-error.yaml', 10 %>
 

--- a/alerts/kube-apiserver-error.yaml
+++ b/alerts/kube-apiserver-error.yaml
@@ -1,0 +1,126 @@
+- alert: ErrorBudgetBurn
+  annotations:
+    runbook_url: https:////github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-errorbudgetburn
+  expr: |-
+    (
+      status_class_5xx:apiserver_request_total:ratio_rate1h{job="apiserver"} > (14.4*0.010000)
+      and
+      status_class_5xx:apiserver_request_total:ratio_rate5m{job="apiserver"} > (14.4*0.010000)
+    )
+    or
+    (
+      status_class_5xx:apiserver_request_total:ratio_rate6h{job="apiserver"} > (6*0.010000)
+      and
+      status_class_5xx:apiserver_request_total:ratio_rate30m{job="apiserver"} > (6*0.010000)
+    )
+  labels:
+    job: apiserver
+    severity: critical
+- alert: ErrorBudgetBurn
+  annotations:
+    runbook_url: https:////github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-errorbudgetburn
+  expr: |-
+    (
+      status_class_5xx:apiserver_request_total:ratio_rate1d{job="apiserver"} > (3*0.010000)
+      and
+      status_class_5xx:apiserver_request_total:ratio_rate2h{job="apiserver"} > (3*0.010000)
+    )
+  labels:
+    job: apiserver
+    severity: warning
+- expr: |-
+    sum by (status_class) (
+      label_replace(
+        rate(apiserver_request_total{job="apiserver"}[5m]
+      ), "status_class", "${1}xx", "code", "([0-9])..")
+    )
+  labels:
+    job: apiserver
+  record: status_class:apiserver_request_total:rate5m
+- expr: |-
+    sum by (status_class) (
+      label_replace(
+        rate(apiserver_request_total{job="apiserver"}[30m]
+      ), "status_class", "${1}xx", "code", "([0-9])..")
+    )
+  labels:
+    job: apiserver
+  record: status_class:apiserver_request_total:rate30m
+- expr: |-
+    sum by (status_class) (
+      label_replace(
+        rate(apiserver_request_total{job="apiserver"}[1h]
+      ), "status_class", "${1}xx", "code", "([0-9])..")
+    )
+  labels:
+    job: apiserver
+  record: status_class:apiserver_request_total:rate1h
+- expr: |-
+    sum by (status_class) (
+      label_replace(
+        rate(apiserver_request_total{job="apiserver"}[2h]
+      ), "status_class", "${1}xx", "code", "([0-9])..")
+    )
+  labels:
+    job: apiserver
+  record: status_class:apiserver_request_total:rate2h
+- expr: |-
+    sum by (status_class) (
+      label_replace(
+        rate(apiserver_request_total{job="apiserver"}[6h]
+      ), "status_class", "${1}xx", "code", "([0-9])..")
+    )
+  labels:
+    job: apiserver
+  record: status_class:apiserver_request_total:rate6h
+- expr: |-
+    sum by (status_class) (
+      label_replace(
+        rate(apiserver_request_total{job="apiserver"}[1d]
+      ), "status_class", "${1}xx", "code", "([0-9])..")
+    )
+  labels:
+    job: apiserver
+  record: status_class:apiserver_request_total:rate1d
+- expr: |-
+    sum(status_class:apiserver_request_total:rate5m{job="apiserver",status_class="5xx"})
+    /
+    sum(status_class:apiserver_request_total:rate5m{job="apiserver"})
+  labels:
+    job: apiserver
+  record: status_class_5xx:apiserver_request_total:ratio_rate5m
+- expr: |-
+    sum(status_class:apiserver_request_total:rate30m{job="apiserver",status_class="5xx"})
+    /
+    sum(status_class:apiserver_request_total:rate30m{job="apiserver"})
+  labels:
+    job: apiserver
+  record: status_class_5xx:apiserver_request_total:ratio_rate30m
+- expr: |-
+    sum(status_class:apiserver_request_total:rate1h{job="apiserver",status_class="5xx"})
+    /
+    sum(status_class:apiserver_request_total:rate1h{job="apiserver"})
+  labels:
+    job: apiserver
+  record: status_class_5xx:apiserver_request_total:ratio_rate1h
+- expr: |-
+    sum(status_class:apiserver_request_total:rate2h{job="apiserver",status_class="5xx"})
+    /
+    sum(status_class:apiserver_request_total:rate2h{job="apiserver"})
+  labels:
+    job: apiserver
+  record: status_class_5xx:apiserver_request_total:ratio_rate2h
+- expr: |-
+    sum(status_class:apiserver_request_total:rate6h{job="apiserver",status_class="5xx"})
+    /
+    sum(status_class:apiserver_request_total:rate6h{job="apiserver"})
+  labels:
+    job: apiserver
+  record: status_class_5xx:apiserver_request_total:ratio_rate6h
+- expr: |-
+    sum(status_class:apiserver_request_total:rate1d{job="apiserver",status_class="5xx"})
+    /
+    sum(status_class:apiserver_request_total:rate1d{job="apiserver"})
+  labels:
+    job: apiserver
+  record: status_class_5xx:apiserver_request_total:ratio_rate1d

--- a/alerts/kube-apiserver-error.yaml
+++ b/alerts/kube-apiserver-error.yaml
@@ -1,6 +1,6 @@
 - alert: ErrorBudgetBurn
   annotations:
-    runbook_url: https:////github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-errorbudgetburn
+    runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-errorbudgetburn
   expr: |-
     (
       status_class_5xx:apiserver_request_total:ratio_rate1h{job="apiserver"} > (14.4*0.010000)
@@ -16,9 +16,10 @@
   labels:
     job: apiserver
     severity: critical
+
 - alert: ErrorBudgetBurn
   annotations:
-    runbook_url: https:////github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-errorbudgetburn
+    runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-errorbudgetburn
   expr: |-
     (
       status_class_5xx:apiserver_request_total:ratio_rate1d{job="apiserver"} > (3*0.010000)
@@ -28,6 +29,7 @@
   labels:
     job: apiserver
     severity: warning
+
 - expr: |-
     sum by (status_class) (
       label_replace(
@@ -37,6 +39,7 @@
   labels:
     job: apiserver
   record: status_class:apiserver_request_total:rate5m
+
 - expr: |-
     sum by (status_class) (
       label_replace(
@@ -46,6 +49,7 @@
   labels:
     job: apiserver
   record: status_class:apiserver_request_total:rate30m
+
 - expr: |-
     sum by (status_class) (
       label_replace(
@@ -55,6 +59,7 @@
   labels:
     job: apiserver
   record: status_class:apiserver_request_total:rate1h
+
 - expr: |-
     sum by (status_class) (
       label_replace(
@@ -64,6 +69,7 @@
   labels:
     job: apiserver
   record: status_class:apiserver_request_total:rate2h
+
 - expr: |-
     sum by (status_class) (
       label_replace(
@@ -73,6 +79,7 @@
   labels:
     job: apiserver
   record: status_class:apiserver_request_total:rate6h
+
 - expr: |-
     sum by (status_class) (
       label_replace(
@@ -82,6 +89,7 @@
   labels:
     job: apiserver
   record: status_class:apiserver_request_total:rate1d
+
 - expr: |-
     sum(status_class:apiserver_request_total:rate5m{job="apiserver",status_class="5xx"})
     /
@@ -89,6 +97,7 @@
   labels:
     job: apiserver
   record: status_class_5xx:apiserver_request_total:ratio_rate5m
+
 - expr: |-
     sum(status_class:apiserver_request_total:rate30m{job="apiserver",status_class="5xx"})
     /
@@ -96,6 +105,7 @@
   labels:
     job: apiserver
   record: status_class_5xx:apiserver_request_total:ratio_rate30m
+
 - expr: |-
     sum(status_class:apiserver_request_total:rate1h{job="apiserver",status_class="5xx"})
     /
@@ -103,6 +113,7 @@
   labels:
     job: apiserver
   record: status_class_5xx:apiserver_request_total:ratio_rate1h
+
 - expr: |-
     sum(status_class:apiserver_request_total:rate2h{job="apiserver",status_class="5xx"})
     /
@@ -110,6 +121,7 @@
   labels:
     job: apiserver
   record: status_class_5xx:apiserver_request_total:ratio_rate2h
+
 - expr: |-
     sum(status_class:apiserver_request_total:rate6h{job="apiserver",status_class="5xx"})
     /
@@ -117,6 +129,7 @@
   labels:
     job: apiserver
   record: status_class_5xx:apiserver_request_total:ratio_rate6h
+
 - expr: |-
     sum(status_class:apiserver_request_total:rate1d{job="apiserver",status_class="5xx"})
     /

--- a/kube-prometheus.yaml.erb
+++ b/kube-prometheus.yaml.erb
@@ -96,6 +96,7 @@ defaultRules:
     kubernetesApps: false
     kubernetesResources: false
     kubernetesSystem: false
+    kubeApiserverError: false
 
 additionalPrometheusRules:
   - name: cf-rules

--- a/lib/vars.rb
+++ b/lib/vars.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 CHARTS = [
-  { chart: 'stable/prometheus-operator', version: '8.5.14', release: 'cprom',
+  { chart: 'stable/prometheus-operator', version: '8.12.3', release: 'cprom',
     values: 'kube-prometheus.yaml', template: 'kube-prometheus.yaml.erb' },
 ].freeze
 


### PR DESCRIPTION
## Overview

To exclude rule evaluation error `query processing would load too many samples into memory in query execution` default [kube-apiserver-error](https://github.com/helm/charts/blob/master/stable/prometheus-operator/templates/prometheus/rules-1.14/kube-apiserver-error.yaml) rules were replaced by custom rules [file](https://github.com/codefresh-io/runtime-cluster-monitor/blob/saas-5604/alerts/kube-apiserver-error.yaml).

Related prometheus-operator issue: https://github.com/coreos/prometheus-operator/issues/3036

## Changes

- Deleting the `status_class:apiserver_request_total:rate3d` record.
- Deleting the `status_class_5xx:apiserver_request_total:ratio_rate3d` record.
- Modifying the `ErrorBudgetBurn` alert.
- Changing the prometheus-operator chart version from **8.5.14** to **8.12.3**.

## Deploy

The prometheusrules CRD `cprom-prometheus-operator-kube-apiserver-error` should be deleted manually.